### PR TITLE
Fix label policy accuracy

### DIFF
--- a/iced_aksel/src/axis.rs
+++ b/iced_aksel/src/axis.rs
@@ -343,7 +343,6 @@ impl<D: Float> Axis<D> {
 
         // --- Prioritize Ticks (Center-Out) ---
 
-        let all_ticks = self.ticks();
         let prioritized_ticks = self.collect_prioritized_ticks();
 
         let mut label_candidates = Vec::new();


### PR DESCRIPTION
Make the skip_overlapping_labels() feature (LabelPolicy) focus on centered minor ticks, instead of having an arbitrary set of labels shown.

![core_interactions_bvFr0uc3tl](https://github.com/user-attachments/assets/33adf544-d700-4904-8c6a-443b7ad8651a)
