### PR TITLE
Add index and total ticks to tickcontext

### DIFF
--- a/examples/core_axes/src/main.rs
+++ b/examples/core_axes/src/main.rs
@@ -320,11 +320,22 @@ fn simple_tick_result() -> impl Fn(TickContext<f64>) -> TickResult + 'static {
     move |ctx: TickContext<f64>| {
         let text = format!("{:.2}", ctx.tick.value);
         let label = ctx.label(text);
+        let middle = ctx.total_ticks / 2;
+
+        let color = if ctx.index < middle {
+            Color::from_rgb8(0, 0, 255)
+        } else {
+            Color::from_rgb8(255, 0, 0)
+        };
 
         TickResult {
             label: Some(label),
             label_badge: Some(ctx.label_badge()),
-            tick_line: Some(ctx.tickline()),
+            tick_line: Some(TickLine {
+                color,
+                length: 5.0.into(),
+                width: 1.0.into(),
+            }),
             grid_line: Some(ctx.gridline()),
             label_priority: None,
         }

--- a/iced_aksel/src/axis.rs
+++ b/iced_aksel/src/axis.rs
@@ -334,6 +334,7 @@ impl<D: Float, Theme> Axis<D, Theme> {
 
         // --- Prioritize Ticks (Center-Out) ---
         let prioritized_ticks = self.collect_prioritized_ticks();
+        let total_ticks = prioritized_ticks.len();
 
         let mut label_candidates = Vec::new();
         let mut candidate_max_bounds = Size::ZERO;
@@ -341,11 +342,14 @@ impl<D: Float, Theme> Axis<D, Theme> {
         // Iterate through the PRE-SORTED ticks
         for wrapper in prioritized_ticks {
             let tick = wrapper.tick;
+            let index = wrapper.index;
             let pos_norm = self.normalize(&tick.value);
 
             let tick_result = self.tick_renderer.as_ref().map(|renderer| {
                 renderer.borrow_mut()(TickContext {
                     tick,
+                    index,
+                    total_ticks,
                     normalized_position: pos_norm,
                     axis_bounds: &bounds,
                     scale_domain: (d_max, d_min),
@@ -1090,7 +1094,7 @@ impl<D: Float, Theme> Axis<D, Theme> {
         major_tick_values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
         // 2. Score every tick
-        for tick in all_ticks {
+        for (index, tick) in all_ticks.into_iter().enumerate() {
             let val = tick.value.to_f32().unwrap_or(0.0);
 
             let score = if tick.level == 0 {
@@ -1122,7 +1126,7 @@ impl<D: Float, Theme> Axis<D, Theme> {
                 }
             };
 
-            prioritized.push(PrioritizedTick { tick, score });
+            prioritized.push(PrioritizedTick { tick, score, index });
         }
 
         // 3. Sort (Stable sort to preserve any internal logic from the scale)

--- a/iced_aksel/src/axis/tick.rs
+++ b/iced_aksel/src/axis/tick.rs
@@ -101,6 +101,10 @@ impl TickResult {
 pub struct TickContext<'a, D, Theme = iced_core::Theme> {
     /// The tick value and metadata from the scale.
     pub tick: Tick<D>,
+    /// The index of the current tick
+    pub index: usize,
+    /// The total amount of ticks to be rendered
+    pub total_ticks: usize,
     /// Normalized position (0.0-1.0) along the axis.
     pub normalized_position: f32,
     /// The bounds of the axis in screen coordinates.
@@ -239,6 +243,9 @@ pub struct PrioritizedTick<D> {
     ///
     /// This will vary based on the [`aksel::Scale`] you use.
     pub tick: aksel::Tick<D>,
+
+    /// The index of the tick
+    pub index: usize,
 
     /// The importance of this tick (lower values are higher priority).
     ///


### PR DESCRIPTION
Allows rendering ticks based on the index:
<img width="938" height="65" alt="image" src="https://github.com/user-attachments/assets/511127e6-b60d-418d-adf2-0518e9b058f0" />

closes #86 